### PR TITLE
移行先リンクの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Misskey for Android
 現在このプロジェクトはメンテナンスされていません。
-こちら　https://github.com/Kinoshita0623/MisskeyAndroidClient　を利用してください。
+こちら　https://github.com/Kinoshita0623/MisskeyAndroidClient を利用してください。
 MisskeyのためのAndroidクライアント（作りかけ）
 ## Description
 これはMisskeyのためのAndroidクライアントです。これは公式のような名前をしていますが非公式クライアントです。


### PR DESCRIPTION
全角空白もリンクの一部として処理されています。半角に置き換えて回避できます